### PR TITLE
Report error

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,10 +14,11 @@ RUN apt install python3.10 python3.10-venv ffmpeg libsm6 libxext6 -y
 
 FROM base as builder1
 
-RUN apt install curl -y
+RUN apt install curl build-essential libssl-dev libffi-dev python3.10-dev -y
 
 RUN curl -O -L "https://golang.org/dl/go1.21.0.linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz
 ENV PATH="${PATH}:/usr/local/go/bin"
+ENV CGO_ENABLED="1"
 
 WORKDIR /app
 
@@ -28,7 +29,11 @@ WORKDIR /app/h-node
 
 COPY src src
 COPY pyproject.toml pyproject.toml
+COPY setup.py setup.py
 COPY requirements.txt requirements.txt
+COPY MANIFEST.in MANIFEST.in
+COPY go.mod go.mod
+COPY go.sum go.sum
 RUN pip install -r requirements.txt && pip install .
 
 FROM base as builder2

--- a/src/h_server/event_queue/db_impl.py
+++ b/src/h_server/event_queue/db_impl.py
@@ -1,9 +1,8 @@
 import logging
-from collections import deque
-from typing import Optional, Tuple
+from typing import Tuple, Dict
 
 import sqlalchemy as sa
-from anyio import Condition, Lock
+from anyio import Condition
 
 from h_server import db
 from h_server.db import models as db_models
@@ -16,82 +15,53 @@ _logger = logging.getLogger()
 
 
 class DbEventQueue(EventQueue):
-    def __init__(self, max_size: Optional[int] = None) -> None:
-        self.queue = deque(maxlen=max_size)
-        self.lock = Lock()
-        self.condition = Condition(self.lock)
-        self.synced = False
+    def __init__(self) -> None:
+        self.condition = Condition()
 
-        self._no_ack_events = {}
+        self._ack_id = 0
+        self._no_ack_events: Dict[int, TaskEvent] = {}
 
-    async def _sync_from_db(self):
-        if not self.synced:
-            async with self.lock:
-                async with db.session_scope() as sess:
-                    offset = 0
-                    limit = 30
-                    while True:
-                        q = (
-                            sa.select(db_models.TaskEvent)
-                            .order_by(db_models.TaskEvent.id)
-                            .limit(limit)
-                            .offset(offset)
-                        )
-                        event_models = (await sess.scalars(q)).all()
-                        if len(event_models) == 0:
-                            break
-                        for event_model in event_models:
-                            event = load_event_from_json(event_model.kind, event_model.event)
-                            self.queue.append((event_model.id, event))
-                        offset += limit
-                self.synced = True
-
-    async def _put(self, id: int, event: TaskEvent):
-        async with self.condition:
-            self.queue.append((id, event))
-            self.condition.notify()
-
-    async def _get(self) -> Tuple[int, TaskEvent]:
-        async with self.condition:
-            while len(self.queue) == 0:
-                await self.condition.wait()
-            id, event = self.queue.popleft()
-            return id, event
+    async def get_count(self) -> int:
+        async with db.session_scope() as sess:
+            q = sa.select(sa.func.count(db_models.TaskEvent.id))
+            count = (await sess.execute(q)).scalar_one()
+        return count
 
     async def put(self, event: TaskEvent):
-        await self._sync_from_db()
+        async with self.condition:
+            async with db.session_scope() as sess:
+                event_str = event.model_dump_json()
+                event_model = db_models.TaskEvent(kind=event.kind, event=event_str)
+                sess.add(event_model)
+                await sess.commit()
+            self.condition.notify(1)
 
-        async with db.session_scope() as sess:
-            event_str = event.model_dump_json()
-            event_model = db_models.TaskEvent(kind=event.kind, event=event_str)
-            sess.add(event_model)
-            await sess.commit()
-            await sess.refresh(event_model)
-            model_id = event_model.id
-
-        await self._put(model_id, event)
         _logger.debug(f"put event {event} to queue")
 
     async def get(self) -> Tuple[int, TaskEvent]:
-        await self._sync_from_db()
 
-        ack_id, event = await self._get()
+        async with self.condition:
+            while (await self.get_count()) <= 0:
+                await self.condition.wait()
+    
+        async with db.session_scope() as sess:
+            q = sa.select(db_models.TaskEvent).order_by(db_models.TaskEvent.id).limit(1)
 
-        self._no_ack_events[ack_id] = event
+            event_model = (await sess.scalars(q)).first()
+            assert event_model is not None
+            await sess.delete(event_model)
+            await sess.commit()
 
-        _logger.debug(f"get {ack_id} event {event}")
-        return ack_id, event
+        event = load_event_from_json(kind=event_model.kind, event_json=event_model.event)
+        self._ack_id += 1
+        self._no_ack_events[self._ack_id] = event
+
+        _logger.debug(f"get {self._ack_id} event {event}")
+        return self._ack_id, event
 
     async def ack(self, ack_id: int):
         if ack_id not in self._no_ack_events:
             raise KeyError(f"Event ack id {ack_id} not found.")
-
-        async with db.session_scope() as sess:
-            q = sa.select(db_models.TaskEvent).where(db_models.TaskEvent.id == ack_id)
-
-            event_model = (await sess.scalars(q)).one()
-            await sess.delete(event_model)
-            await sess.commit()
 
         event = self._no_ack_events.pop(ack_id)
         _logger.debug(f"ack {ack_id} event {event}")
@@ -101,5 +71,5 @@ class DbEventQueue(EventQueue):
             raise KeyError(f"Event ack id {ack_id} not found.")
 
         event = self._no_ack_events.pop(ack_id)
-        await self._put(ack_id, event)
+        await self.put(event)
         _logger.debug(f"no ack {ack_id} event {event}")

--- a/src/h_server/models/task.py
+++ b/src/h_server/models/task.py
@@ -60,6 +60,7 @@ class TaskStatus(Enum):
     Disclosed = "disclosed"
     Success = "success"
     Aborted = "aborted"
+    Error = "error"
 
 
 class TaskState(BaseModel):

--- a/src/h_server/task/task_runner.py
+++ b/src/h_server/task/task_runner.py
@@ -89,7 +89,7 @@ def wrap_task_error():
     except Exception as e:
         _logger.exception(e)
         _logger.error("Task unknown error")
-        raise TaskError(str(e), TaskErrorSource.Unknown, retry=False)
+        raise TaskError(str(e), TaskErrorSource.Unknown, retry=True)
 
 
 class InferenceTaskRunner(TaskRunner):
@@ -104,6 +104,7 @@ class InferenceTaskRunner(TaskRunner):
         relay: Optional[Relay] = None,
         watcher: Optional[EventWatcher] = None,
         local_config: Optional[LocalConfig] = None,
+        retry_count: Optional[int] = 5,
     ) -> None:
         super().__init__(
             task_id=task_id,
@@ -137,6 +138,9 @@ class InferenceTaskRunner(TaskRunner):
                 self.local_config = local_config
         else:
             self.local_config = None
+
+        # Error retry count limit. None means no limit.
+        self._retry_count = retry_count
 
         self._state: Optional[models.TaskState] = None
 
@@ -192,15 +196,18 @@ class InferenceTaskRunner(TaskRunner):
         assert self._state is not None, "The task runner has not been initialized."
 
         round = self._state.round
+        self._state.status = models.TaskStatus.Error
 
         try:
             waiter = await self.contracts.task_contract.report_task_error(
                 self.task_id, round
             )
             await waiter.wait()
+            await self.cleanup()
         except TxRevertedError as e:
             _logger.exception(e)
             _logger.error("Task report error being reverted")
+            # cannot report error, need retry
             raise TaskError(str(e), TaskErrorSource.Contracts, retry=True)
         except Exception as e:
             _logger.exception(e)
@@ -214,6 +221,12 @@ class InferenceTaskRunner(TaskRunner):
         except get_cancelled_exc_class() as e:
             raise
         except TaskError as e:
+            # limit error retry count
+            if self._retry_count is not None and e.retry:
+                if self._retry_count == 0:
+                    e.retry = False
+                else:
+                    self._retry_count -= 1
             if not e.retry:
                 await self._report_error()
             raise e
@@ -400,10 +413,11 @@ class InferenceTaskRunner(TaskRunner):
 
     async def cleanup(self):
         assert self._state is not None, "The task runner has not been initialized."
-        assert (
-            self._state.status == models.TaskStatus.Success
-            or self._state.status == models.TaskStatus.Aborted
-        ), "Task status is not success or aborted when shutdown."
+        assert self._state.status in [
+            models.TaskStatus.Success,
+            models.TaskStatus.Aborted,
+            models.TaskStatus.Error,
+        ], "Task status is not success or aborted when shutdown."
 
         self.watcher.unwatch_event(self._success_watch_id)
         self.watcher.unwatch_event(self._aborted_watch_id)

--- a/src/h_worker/prefetch.py
+++ b/src/h_worker/prefetch.py
@@ -31,7 +31,7 @@ def _check_model_checksum(path: str, model: str) -> bool:
     return cksum == base_model_cksum[model]
 
 
-def _prefetch_base_model(
+def prefetch_base_model(
     client: httpx.Client, pretrained_models_dir: str, base_model: str
 ):
     base_model_path = os.path.join(
@@ -57,34 +57,40 @@ def _prefetch_base_model(
                     f.write(chunk)
         _logger.info(f"Base model {base_model} download finished")
 
+huggingface_script = """
+import os
+from transformers import CLIPTextModel, CLIPTokenizer
 
-def _prefetch_huggingface(huggingface_cache_dir: str, script_dir: str):
+try:
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    CLIPTokenizer.from_pretrained('openai/clip-vit-large-patch14')
+    CLIPTextModel.from_pretrained('openai/clip-vit-large-patch14')
+except OSError:
+    os.environ["TRANSFORMERS_OFFLINE"] = "0"
+    CLIPTokenizer.from_pretrained('openai/clip-vit-large-patch14')
+    CLIPTextModel.from_pretrained('openai/clip-vit-large-patch14')
+"""
+
+def prefetch_huggingface(huggingface_cache_dir: str, script_dir: str):
     exe = "python"
     worker_venv = os.path.abspath(os.path.join(script_dir, "venv"))
     if os.path.exists(worker_venv):
         exe = os.path.join(worker_venv, "bin", "python")
 
-    args = [
-        exe,
-        "-c",
-        "from transformers import CLIPTextModel, CLIPTokenizer;"
-        "CLIPTokenizer.from_pretrained('openai/clip-vit-large-patch14');"
-        "CLIPTextModel.from_pretrained('openai/clip-vit-large-patch14')",
-    ]
+    script_file = os.path.abspath(os.path.join(script_dir, "prefetch.py"))
+    with open(script_file, mode="w", encoding="utf-8") as f:
+        f.write(huggingface_script)
 
-    envs = os.environ.copy()
-    hf_home = os.path.abspath(huggingface_cache_dir)
-    envs["HF_HOME"] = hf_home
-    # check model in offline mode
-    envs["TRANSFORMERS_OFFLINE"] = "1"
     try:
-        subprocess.check_call(args, env=envs, cwd=script_dir)
-    except OSError:
-        # model not exists, download model in online mode
-        envs["TRANSFORMERS_OFFLINE"] = "0"
-        subprocess.check_call(args, env=envs, cwd=script_dir)
-    _logger.info(f"Model openai/clip-vit-large-patch14 download finished")
+        args = [exe, script_file]
 
+        envs = os.environ.copy()
+        hf_home = os.path.abspath(huggingface_cache_dir)
+        envs["HF_HOME"] = hf_home
+        subprocess.check_call(args, env=envs, cwd=script_dir)
+        _logger.info(f"Model openai/clip-vit-large-patch14 download finished")
+    finally:
+        os.remove(script_file)
 
 def prefetch(pretrained_models_dir: str, huggingface_cache_dir: str, script_dir: str):
     if not os.path.exists(pretrained_models_dir):
@@ -96,9 +102,9 @@ def prefetch(pretrained_models_dir: str, huggingface_cache_dir: str, script_dir:
     try:
         with httpx.Client() as client:
             for base_model in base_model_urls:
-                _prefetch_base_model(client, pretrained_models_dir, base_model)
+                prefetch_base_model(client, pretrained_models_dir, base_model)
 
-        _prefetch_huggingface(huggingface_cache_dir, script_dir)
+        prefetch_huggingface(huggingface_cache_dir, script_dir)
     except Exception as e:
         _logger.exception(e)
         _logger.error("Prefetch error")

--- a/tests/worker/prefetch_test.py
+++ b/tests/worker/prefetch_test.py
@@ -1,0 +1,16 @@
+from h_worker.prefetch import prefetch_huggingface, prefetch
+
+
+def test_prefetch_huggingface():
+    prefetch_huggingface(
+        "remote-lora-scripts/huggingface",
+        "remote-lora-scripts",
+    )
+
+
+def test_prefetch():
+    prefetch(
+        "build/data/pretrained-models",
+        "remote-lora-scripts/huggingface",
+        "remote-lora-scripts",
+    )


### PR DESCRIPTION
- bug fix: avoid get a no-ack event after restarting
- wrap exception in report error into a TaskError
- mark task finished when a no-retry error occurs
- clean up task after report error; limit task error retry count
- use offline mode to check huggingface model in prefetching; download huggingface when offline check failed
- bug fix: build imhash in docker correctly