### PR TITLE
bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-multipart==0.0.6",
     "tenacity~=8.2.3",
 ]
-version = "0.2.0"
+version = "0.2.1"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/h_server/node_manager/node_manager.py
+++ b/src/h_server/node_manager/node_manager.py
@@ -347,7 +347,7 @@ class NodeManager(object):
                     raise
                 except Exception as e:
                     _logger.exception(e)
-                    msg = f"Node manager init error: {str(e)}"
+                    msg = f"Node manager init error: {e}"
                     _logger.error(msg)
                     with fail_after(5, shield=True):
                         await self.state_cache.set_node_state(models.NodeStatus.Error, msg)
@@ -375,7 +375,7 @@ class NodeManager(object):
             raise
         except Exception as e:
             _logger.exception(e)
-            msg = f"Node manager running error: {str(e)}"
+            msg = f"Node manager running error: {e}"
             _logger.error(msg)
             with fail_after(5, shield=True):
                 await self.state_cache.set_node_state(models.NodeStatus.Error, msg)

--- a/src/h_server/task/state_cache/abc.py
+++ b/src/h_server/task/state_cache/abc.py
@@ -19,10 +19,10 @@ class TaskStateCache(ABC):
         ...
 
     @abstractmethod
-    async def count(
+    async def find(
         self,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         status: Optional[List[models.TaskStatus]] = None
-    ) -> int:
+    ) -> List[models.TaskState]:
         ...

--- a/src/h_server/task/state_cache/db_impl.py
+++ b/src/h_server/task/state_cache/db_impl.py
@@ -62,14 +62,14 @@ class DbTaskStateCache(TaskStateCache):
             state = (await sess.scalars(q)).one_or_none()
             return state is not None
 
-    async def count(
+    async def find(
         self,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         status: Optional[List[TaskStatus]] = None
     ):
         async with db.session_scope() as sess:
-            q = sa.select(sa.func.count(db_models.TaskState.id))
+            q = sa.select(db_models.TaskState)
             if start is not None:
                 q = q.where(db_models.TaskState.updated_at >= start)
             if end is not None:
@@ -77,5 +77,5 @@ class DbTaskStateCache(TaskStateCache):
             if status is not None:
                 q = q.where(db_models.TaskState.status.in_(status))
 
-            n = (await sess.execute(q)).scalar_one()
-            return n
+            states = (await sess.execute(q)).scalars().all()
+            return list(states)

--- a/src/h_server/task/state_cache/memory_impl.py
+++ b/src/h_server/task/state_cache/memory_impl.py
@@ -24,7 +24,7 @@ class MemoryTaskStateCache(TaskStateCache):
     async def has(self, task_id: int) -> bool:
         return task_id in self._states
 
-    async def count(
+    async def find(
         self,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
@@ -49,4 +49,4 @@ class MemoryTaskStateCache(TaskStateCache):
                 for task_id, state in states.items()
                 if state.status in status
             }
-        return len(states)
+        return list(states.values())

--- a/src/h_server/task/task_runner.py
+++ b/src/h_server/task/task_runner.py
@@ -11,8 +11,10 @@ from tenacity import (
     AsyncRetrying,
     before_sleep_log,
     retry,
+    retry_if_exception,
     retry_if_not_exception_type,
     stop_after_attempt,
+    stop_after_delay,
     wait_exponential,
     wait_fixed,
 )
@@ -23,7 +25,7 @@ from h_server.config import TaskConfig as LocalConfig
 from h_server.config import get_config
 from h_server.contracts import Contracts, TxRevertedError, get_contracts
 from h_server.event_queue import EventQueue
-from h_server.relay import Relay, get_relay
+from h_server.relay import Relay, get_relay, RelayError
 from h_server.watcher import EventWatcher, get_watcher
 from h_worker.task.error import TaskInvalid
 
@@ -198,7 +200,7 @@ class InferenceTaskRunner(TaskRunner):
         try:
             async for attemp in AsyncRetrying(
                 stop=stop_after_attempt(self._retry_count),
-                wait=wait_exponential(multiplier=3, max=60),
+                wait=wait_exponential(multiplier=10),
                 retry=retry_if_not_exception_type((TaskInvalid, AssertionError)),
                 before_sleep=before_sleep_log(_logger, logging.ERROR, exc_info=True),
                 reraise=True,
@@ -243,7 +245,22 @@ class InferenceTaskRunner(TaskRunner):
 
             state.round = event.round
 
-            task = await self.relay.get_task(event.task_id)
+            def should_retry(e: BaseException) -> bool:
+                if isinstance(e, RelayError) and "Task not ready" in e.message:
+                    return True
+                return False
+            
+            @retry(
+                stop=stop_after_delay(1800),
+                wait=wait_fixed(60),
+                retry=retry_if_exception(should_retry),
+                before_sleep=before_sleep_log(_logger, logging.ERROR, exc_info=True),
+                reraise=True,
+            )
+            async def get_task():
+                return await self.relay.get_task(event.task_id)
+                
+            task = await get_task()
 
             if self.distributed:
 

--- a/src/h_server/watcher/watcher.py
+++ b/src/h_server/watcher/watcher.py
@@ -107,6 +107,9 @@ class EventWatcher(object):
     def set_blocknumber_cache(self, cache: BlockNumberCache):
         self._cache = cache
 
+    def get_blocknumber_cache(self):
+        return self._cache
+
     def remove_blocknumber_cache(self):
         self._cache = None
 

--- a/src/h_server/watcher/watcher.py
+++ b/src/h_server/watcher/watcher.py
@@ -45,32 +45,17 @@ class EventFilter(object):
         self.from_block = from_block
         self.to_block = to_block
 
-    def process_tx(self, tx: TxReceipt, tg: TaskGroup):
-        block_number = tx["blockNumber"]
-        if self.from_block is not None and self.from_block >= block_number:
-            return
-        if self.to_block is not None and self.to_block < block_number:
-            return
-        if tx["to"] != self.event.address:
-            return
-        for event in self.event.process_receipt(tx, errors=DISCARD):
-            if _filter_event(event, self.filter_args):
+    async def process_events(self, start: int, end: int, tg: TaskGroup):
+        if self.from_block is not None:
+            start = max(self.from_block, start)
+        if self.to_block is not None:
+            end = min(self.to_block, end)
+        
+        if start <= end:
+            events = await self.event.get_logs(argument_filters=self.filter_args, fromBlock=start, toBlock=end)
+            for event in events:
                 _logger.debug(f"Watch event: {event}")
                 tg.start_soon(wrap_callback(self.callback), event)
-
-
-def _filter_event(event: EventData, filter_args: Optional[Dict[str, Any]]) -> bool:
-    if filter_args is None:
-        return True
-    for key, value in filter_args.items():
-        real = event["args"][key]
-        if isinstance(value, list):
-            if real not in value:
-                return False
-        elif real != value:
-            return False
-
-    return True
 
 
 class EventWatcher(object):
@@ -78,6 +63,7 @@ class EventWatcher(object):
         self, w3: AsyncWeb3, retry_count: int = 3, retry_delay: float = 10
     ) -> None:
         self.w3 = w3
+        self.page_size = 500
         self.retry_count = retry_count
         self.retry_delay = retry_delay
 
@@ -170,13 +156,14 @@ class EventWatcher(object):
                 start = await self._cache.get()
                 if start == 0:
                     start = await self.w3.eth.get_block_number()
+                else:
+                    start += 1
             else:
                 start = await self.w3.eth.get_block_number()
         else:
             if self._cache is not None:
-                await self._cache.set(from_block)
+                await self._cache.set(from_block - 1)
             start = from_block
-        start += 1
 
         def _should_stop(stop_event: Event, start: int):
             if stop_event.is_set():
@@ -198,24 +185,19 @@ class EventWatcher(object):
                     with attemp:
 
                         while not _should_stop(self._stop_event, start):
-                            if start <= (await self.w3.eth.get_block_number()):
-                                block = await self.w3.eth.get_block(start)
-                                _logger.debug(f"Get block {start} from chain.")
-                                if "transactions" in block and len(self._event_filters) > 0:
+                            latest_blocknum = await self.w3.eth.get_block_number()
+                            if start <= latest_blocknum:
+                                end = min(latest_blocknum, start + self.page_size)
+                                if len(self._event_filters) > 0:
                                     async with create_task_group() as tg:
-                                        for tx_hash in block["transactions"]:
-                                            assert isinstance(tx_hash, bytes)
-                                            tx = await self.w3.eth.get_transaction_receipt(
-                                                tx_hash
-                                            )
-                                            for event_filter in self._event_filters.values():
-                                                event_filter.process_tx(tx, tg=tg)
-
-                                start += 1
+                                        for event_filter in self._event_filters.values():
+                                            tg.start_soon(event_filter.process_events, start, end, tg)
+                                _logger.debug(f"Process events from block {start} to {end}")
 
                                 with fail_after(delay=5, shield=True):
                                     if self._cache is not None:
-                                        await self._cache.set(start)
+                                        await self._cache.set(end)
+                                start = end + 1
                             else:
                                 await sleep(interval)
         finally:

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 if [ ! -f config/config.yml ]; then
+    mkdir -p config
     cp config.yml.example config/config.yml
 fi
 python3 -m h_server.main

--- a/tests/server/task/state_cache_test.py
+++ b/tests/server/task/state_cache_test.py
@@ -27,19 +27,19 @@ async def test_memory_state_cache():
 
     assert await cache.has(state.task_id)
 
-    assert await cache.count() == 1
-    assert await cache.count(start=start, end=datetime.now()) == 1
-    assert await cache.count(start=datetime.now()) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Pending]) == 1
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Success]) == 0
+    assert len(await cache.find()) == 1
+    assert len(await cache.find(start=start, end=datetime.now())) == 1
+    assert len(await cache.find(start=datetime.now())) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Pending])) == 1
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Success])) == 0
 
     state.status = TaskStatus.Success
     await cache.dump(state)
-    assert await cache.count() == 1
-    assert await cache.count(start=start, end=datetime.now()) == 1
-    assert await cache.count(start=datetime.now()) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Pending]) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Success]) == 1
+    assert len(await cache.find()) == 1
+    assert len(await cache.find(start=start, end=datetime.now())) == 1
+    assert len(await cache.find(start=datetime.now())) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Pending])) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Success])) == 1
 
 
 @pytest.fixture
@@ -68,16 +68,16 @@ async def test_db_state_cache(init_db):
     assert state == _state
 
     assert await cache.has(state.task_id)
-    assert await cache.count() == 1
-    assert await cache.count(start=start, end=datetime.now()) == 1
-    assert await cache.count(start=datetime.now()) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Pending]) == 1
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Success]) == 0
+    assert len(await cache.find()) == 1
+    assert len(await cache.find(start=start, end=datetime.now())) == 1
+    assert len(await cache.find(start=datetime.now())) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Pending])) == 1
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Success])) == 0
 
     state.status = TaskStatus.Success
     await cache.dump(state)
-    assert await cache.count() == 1
-    assert await cache.count(start=start, end=datetime.now()) == 1
-    assert await cache.count(start=datetime.now()) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Pending]) == 0
-    assert await cache.count(start=start, end=datetime.now(), status=[TaskStatus.Success]) == 1
+    assert len(await cache.find()) == 1
+    assert len(await cache.find(start=start, end=datetime.now())) == 1
+    assert len(await cache.find(start=datetime.now())) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Pending])) == 0
+    assert len(await cache.find(start=start, end=datetime.now(), status=[TaskStatus.Success])) == 1


### PR DESCRIPTION
- bug fix: mkdir before cp in start.sh
- bug fix: recover from task state cache when task system start
- bug fix: get today successful task correctly
- bug fix: recover only when watcher hasn't started
- init only when error occurs in init stage
- retry when task not ready during getting task
- batched scan block in watcher to speed up
- skip task that reported error in recovering